### PR TITLE
update kalnoy/nestedset to 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ext-intl": "*",
         "ext-zip": "*",
         "fideloper/proxy": "^4.0",
-        "kalnoy/nestedset": "^5.0",
+        "kalnoy/nestedset": "^6.0",
         "laravel/framework": "^8.0",
         "laravel/legacy-factories": "^1.1",
         "laravel/tinker": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c9a8f1062251e1b3ab1acedf6d14294f",
+    "content-hash": "2486dd657c7d1b6fcc85a044e96a8586",
     "packages": [
         {
             "name": "brick/math",
@@ -725,22 +725,22 @@
         },
         {
             "name": "kalnoy/nestedset",
-            "version": "v5.0.3",
+            "version": "v6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lazychaser/laravel-nestedset.git",
-                "reference": "789a70bce94a7c3bd206fb05fa4b747cf27acbe2"
+                "reference": "f5351234588a20b14134980552b1bf6dccb3e733"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lazychaser/laravel-nestedset/zipball/789a70bce94a7c3bd206fb05fa4b747cf27acbe2",
-                "reference": "789a70bce94a7c3bd206fb05fa4b747cf27acbe2",
+                "url": "https://api.github.com/repos/lazychaser/laravel-nestedset/zipball/f5351234588a20b14134980552b1bf6dccb3e733",
+                "reference": "f5351234588a20b14134980552b1bf6dccb3e733",
                 "shasum": ""
             },
             "require": {
-                "illuminate/database": "~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-                "illuminate/events": "~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
-                "illuminate/support": "~5.7.0|~5.8.0|^6.0|^7.0|^8.0",
+                "illuminate/database": "^7.0|^8.0",
+                "illuminate/events": "^7.0|^8.0",
+                "illuminate/support": "^7.0|^8.0",
                 "php": ">=7.1.3"
             },
             "require-dev": {
@@ -782,9 +782,9 @@
             ],
             "support": {
                 "issues": "https://github.com/lazychaser/laravel-nestedset/issues",
-                "source": "https://github.com/lazychaser/laravel-nestedset/tree/v5.0.3"
+                "source": "https://github.com/lazychaser/laravel-nestedset/tree/v6.0.0"
             },
-            "time": "2020-12-07T05:59:45+00:00"
+            "time": "2021-05-28T07:08:55+00:00"
         },
         {
             "name": "laravel/framework",
@@ -8747,5 +8747,5 @@
         "ext-zip": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
because the latest version ^5 is not compatible with the latest laravel updates.
see latest ^5 update: https://github.com/lazychaser/laravel-nestedset/commit/abf4c8602977874368a79eb6648d5d0014b613bb

v6.0 only removes getRelationQuery() which we don't use, so I updated to recieve potential future bugfixes of nestedset. See: https://github.com/lazychaser/laravel-nestedset/commit/f5351234588a20b14134980552b1bf6dccb3e733

_Ist mir bei einem eigenen Projekt grad aufgefallen...._

**Changed**
updated nestedset dependency to latest major version

**New**
* 

**Fixed**
* 
